### PR TITLE
Add Rails 4 support

### DIFF
--- a/lib/serialize_with_options.rb
+++ b/lib/serialize_with_options.rb
@@ -67,14 +67,11 @@ module SerializeWithOptions
   end
 
   module InstanceMethods
-    def to_xml(*args)
-      set, opts = parse_serialization_options(args)
-      super(self.class.serialization_options(set).deep_merge(opts))
-    end
-
-    def as_json(*args)
-      set, opts = parse_serialization_options(args)
-      super(self.class.serialization_options(set).deep_merge(opts))
+    %w(to_xml to_json as_json).each do |method_name|
+      define_method method_name do |*args|
+        set, opts = parse_serialization_options(args)
+        super self.class.serialization_options(set).deep_merge(opts)
+      end
     end
 
     private

--- a/serialize_with_options.gemspec
+++ b/serialize_with_options.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "activerecord", "~> 3.0"
+  s.add_dependency "activerecord", "~> 4.0"
 
   s.add_development_dependency "shoulda"
   s.add_development_dependency "sqlite3"

--- a/test/serialize_with_options_test.rb
+++ b/test/serialize_with_options_test.rb
@@ -78,7 +78,7 @@ class Review < ActiveRecord::Base
   end
 end
 
-class SerializeWithOptionsTest < Test::Unit::TestCase
+class SerializeWithOptionsTest < Minitest::Test
   def self.should_serialize_with_options
     should "include active_record attributes" do
       assert_equal @user.name, @user_hash["name"]
@@ -181,15 +181,15 @@ class SerializeWithOptionsTest < Test::Unit::TestCase
 
       should "serialize the associated object properly" do
         review_hash = Hash.from_xml(@review.to_xml)
-        assert_equal @user.email, review_hash["review"]["reviewable"]["email"]
+        assert_equal @user.name, review_hash["review"]["reviewable"]["name"]
       end
     end
 
     context "being converted to JSON" do
       setup do
-        @user_hash = JSON.parse(@user.to_json)["user"]
-        @post_hash = JSON.parse(@post.to_json)["post"]
-        @blog_post_hash = JSON.parse(@blog_post.to_json)["blog_post"]
+        @user_hash = JSON.parse(@user.to_json)
+        @post_hash = JSON.parse(@post.to_json)
+        @blog_post_hash = JSON.parse(@blog_post.to_json)
       end
 
       should_serialize_with_options
@@ -216,7 +216,7 @@ class SerializeWithOptionsTest < Test::Unit::TestCase
       end
 
       should "find associations with multi-word names" do
-        user_hash = JSON.parse(@user.to_json(:with_check_ins))["user"]
+        user_hash = JSON.parse(@user.to_json(:with_check_ins))
         assert_equal @check_in.code_name, user_hash['check_ins'].first['code_name']
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ $:.unshift(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'
 require 'active_record'
-require 'test/unit'
+require 'minitest/autorun'
 require 'shoulda'
 require 'json'
 require 'serialize_with_options'


### PR DESCRIPTION
Quite a few things needed to be addressed to make this happen:
- Bump AR version in gemspec
- Use Ruby's 1.9+ MiniTest instead of TestUnit.
- [This test](https://github.com/vigetlabs/serialize_with_options/blob/d792a472431c72b93dd00b14e7654a8f2c7ebb89/test/serialize_with_options_test.rb#L184) was failing due to the `except` option [here](https://github.com/vigetlabs/serialize_with_options/blob/master/test/serialize_with_options_test.rb#L12). "email" was replaced with "name".
- The [`encode` method within ActiveSupport](https://github.com/rails/rails/blob/4-1-6/activesupport/lib/active_support/json/encoding.rb#L34) calls `dup` on `options`. When using `to_json`, we were allowing the Symbol for `set` to be passed to this method. `dup` cannot be called on Symbol, so `to_json` had to be added back as a method that we parse the options for.
